### PR TITLE
[HOTFIX] pipeline failing without id_only because of missing outputs

### DIFF
--- a/modules/local/mzmlstatistics/main.nf
+++ b/modules/local/mzmlstatistics/main.nf
@@ -15,7 +15,7 @@ process MZMLSTATISTICS {
 
     output:
     path "*_ms_info.tsv", emit: ms_statistics
-    tuple val(meta), path("*_spectrum_df.csv"), emit: spectrum_df
+    tuple val(meta), path("*_spectrum_df.csv"), emit: spectrum_df, optional: true
     path "versions.yml", emit: version
     path "*.log", emit: log
 


### PR DESCRIPTION
I'm wondering how the tests in the id_only PR could pass but I am pretty sure that is a bug.
I cannot get a DIANN workflow to work without this.
<!--
# nf-core/quantms pull request

Many thanks for contributing to nf-core/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
