### PR TITLE
Make validation of ontology terms optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] nfcore/quantms
+
+### `Added`
+
+- [#386](https://github.com/bigbio/quantms/pull/386) Make validation of ontology terms optional
+
+### `Changed`
+
+### `Fixed`
+
+### `Dependencies`
+
+### `Parameters`
+
+- `validate_ontologies`: enable or disable validating ontologies in the input SDRF file.
+
 ## [1.3.0] nfcore/quantms - [08/04/2024] - Santiago de Cuba
 
 ### `Added`

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -124,7 +124,7 @@ def main(args=None):
     args = parse_args(args)
 
     if args.ISSDRF == "true":
-        check_sdrf(args.CHECK_MS, args.SDRF, args.VALIDATE_ONTOLOGIES)
+        check_sdrf(args.CHECK_MS, args.SDRF, args.VALIDATE_ONTOLOGIES == "true")
     else:
         check_expdesign(args.SDRF)
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -20,6 +20,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
     parser.add_argument("SDRF", help="SDRF/Expdesign file to be validated")
     parser.add_argument("ISSDRF", help="SDRF file or Expdesign file")
+    parser.add_argument("VALIDATE_ONTOLOGIES", help="Validate ontology terms.")
     parser.add_argument("--CHECK_MS", help="check mass spectrometry fields in SDRF.", action="store_true")
 
     return parser.parse_args(args)
@@ -44,18 +45,24 @@ def print_error(error, context="Line", context_str=""):
     sys.exit(1)
 
 
-def check_sdrf(check_ms, sdrf):
+def check_sdrf(check_ms, sdrf, validate_ontologies):
     df = SdrfDataFrame.parse(sdrf)
-    errors = df.validate(DEFAULT_TEMPLATE)
-    if check_ms:
-        errors = errors + df.validate(MASS_SPECTROMETRY)
-    for error in errors:
-        print(error)
-    if not errors:
-        print("Everying seems to be fine. Well done.")
+    if validate_ontologies:
+        errors = df.validate(DEFAULT_TEMPLATE)
+        if check_ms:
+            errors = errors + df.validate(MASS_SPECTROMETRY)
+        for error in errors:
+            print(error)
+        if not errors:
+            print("Everying seems to be fine. Well done.")
+        else:
+            print("There were validation errors!")
     else:
-        print("There were validation errors!")
+        errors = False
+        print("No ontology term validation was performed.")
+
     sys.exit(bool(errors))
+
 
 
 def check_expdesign(expdesign):
@@ -117,7 +124,7 @@ def main(args=None):
     args = parse_args(args)
 
     if args.ISSDRF == "true":
-        check_sdrf(args.CHECK_MS, args.SDRF)
+        check_sdrf(args.CHECK_MS, args.SDRF, args.VALIDATE_ONTOLOGIES)
     else:
         check_expdesign(args.SDRF)
 

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -13,6 +13,7 @@ process SAMPLESHEET_CHECK {
     input:
     path input_file
     val is_sdrf
+    val validate_ontologies
 
     output:
     path "*.log", emit: log
@@ -27,7 +28,7 @@ process SAMPLESHEET_CHECK {
     def args = task.ext.args ?: ''
 
     """
-    check_samplesheet.py "${input_file}" ${is_sdrf} --CHECK_MS 2>&1 | tee input_check.log
+    check_samplesheet.py "${input_file}" ${is_sdrf} ${validate_ontologies} --CHECK_MS 2>&1 | tee input_check.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
 
     // Input options
     input                      = null
+    validate_ontologies        = true
 
     // Tools flags
     posterior_probabilities  = 'percolator'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -70,6 +70,12 @@
                     "description": "Whether export PSM from decoy in final identification results",
                     "fa_icon": "far fa-check-square",
                     "help_text": "Whether export PSM from decoy in final identification results for dda_id subworkflow for specific cases."
+                },
+                "validate_ontologies": {
+                    "type": "boolean",
+                    "description": "Check that ontology terms in an input SDRF file exist.",
+                    "fa_icon": "far fa-check-square",
+                    "help_text": "If false, only a basic readability check is performed on an input SDRF file. This option is useful when ontology providers are inaccessible."
                 }
             }
         },

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -18,7 +18,7 @@ workflow INPUT_CHECK {
             exit 1
         }
     }
-    SAMPLESHEET_CHECK ( input_file, is_sdrf )
+    SAMPLESHEET_CHECK ( input_file, is_sdrf, params.validate_ontologies )
 
     emit:
     ch_input_file   = SAMPLESHEET_CHECK.out.checked_file


### PR DESCRIPTION
This PR is our hotfix to address #385 by adding the `validate_ontologies` parameter. When `false` the `SAMPLESHEET_CHECK` process will only parse the SDRF file, but will not perform validation. 

I'm sure there is a more elegant solution, but I thought this might be helpful as a starting point. Please feel free to ignore if it doesn't go in the right direction.

I'm also happy to add a test if someone could point me in the right direction 😉.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
