### PR TITLE
Add verification for tar unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#396](https://github.com/bigbio/quantms/pull/396) Added verification of tar archive unpacking to prevent silent failures.
+
 ### `Dependencies`
 
 ### `Parameters`

--- a/modules/local/decompress_dotd/main.nf
+++ b/modules/local/decompress_dotd/main.nf
@@ -67,9 +67,9 @@ process DECOMPRESS {
         else
             if [ -f \$1 ]; then
                 case \$1 in
-                    *.tar.gz)    tar xvzf \$1 && validate_tar \$1               ;;
+                    *.tar.gz)    tar xvzf \$1 && verify_tar \$1               ;;
                     *.gz)        gunzip \$1                                     ;;
-                    *.tar)       tar xvf \$1 && validate_tar \$1                ;;
+                    *.tar)       tar xvf \$1 && verify_tar \$1                ;;
                     *.zip)       unzip \$1                                      ;;
                     *)           echo "extract: '\$1' - unknown archive method" ;;
                 esac

--- a/modules/local/decompress_dotd/main.nf
+++ b/modules/local/decompress_dotd/main.nf
@@ -41,7 +41,7 @@ process DECOMPRESS {
     """
     function verify_tar {
         exit_code=0
-        error=$(tar df \$1 2>&1) || exit_code=$?
+        error=\$(tar df \$1 2>&1) || exit_code=\$?
         if [ \$exit_code -eq 2 ]; then
             echo "\${error}"
             exit 2

--- a/modules/local/decompress_dotd/main.nf
+++ b/modules/local/decompress_dotd/main.nf
@@ -39,17 +39,39 @@ process DECOMPRESS {
     String prefix = task.ext.prefix ?: "${meta.mzml_id}"
 
     """
+    function verify_tar {
+        exit_code=0
+        error=$(tar df \$1 2>&1) || exit_code=$?
+        if [ \$exit_code -eq 2 ]; then
+            echo "\${error}"
+            exit 2
+        fi
+
+        case \${error} in
+            *'No such file'* )
+                echo "\${error}" | grep "No such file"
+                exit 1
+                ;;
+            *'Size differs'* )
+                echo "\${error}" | grep "Size differs"
+                exit 1
+                ;;
+        esac
+    }
+
+
+
     function extract {
         if [ -z "\$1" ]; then
             echo "Usage: extract <path/file_name>.<gz|tar|tar.bz2>"
         else
             if [ -f \$1 ]; then
                 case \$1 in
-                    *.tar.gz)    tar xvzf \$1 && tar dvf \$1 \$(find . -type d -name '*[!.tar.gz]') ;;
-                    *.gz)        gunzip \$1                                                         ;;
-                    *.tar)       tar xvf \$1 && tar dvf \$1 \$(find . -type d -name '*[!.tar]')     ;;
-                    *.zip)       unzip \$1                                                          ;;
-                    *)           echo "extract: '\$1' - unknown archive method"                     ;;
+                    *.tar.gz)    tar xvzf \$1 && validate_tar \$1               ;;
+                    *.gz)        gunzip \$1                                     ;;
+                    *.tar)       tar xvf \$1 && validate_tar \$1                ;;
+                    *.zip)       unzip \$1                                      ;;
+                    *)           echo "extract: '\$1' - unknown archive method" ;;
                 esac
             else
                 echo "\$1 - file does not exist"

--- a/modules/local/decompress_dotd/main.nf
+++ b/modules/local/decompress_dotd/main.nf
@@ -45,11 +45,11 @@ process DECOMPRESS {
         else
             if [ -f \$1 ]; then
                 case \$1 in
-                    *.tar.gz)    tar xvzf \$1    ;;
-                    *.gz)        gunzip \$1      ;;
-                    *.tar)       tar xvf \$1     ;;
-                    *.zip)       unzip \$1     ;;
-                    *)           echo "extract: '\$1' - unknown archive method" ;;
+                    *.tar.gz)    tar xvzf \$1 && tar dvf \$1 \$(basename \$1 .tar.gz) ;;
+                    *.gz)        gunzip \$1                                           ;;
+                    *.tar)       tar xvf \$1 && tar dvf \$1 \$(basename \$1 .tar)     ;;
+                    *.zip)       unzip \$1                                            ;;
+                    *)           echo "extract: '\$1' - unknown archive method"       ;;
                 esac
             else
                 echo "\$1 - file does not exist"

--- a/modules/local/decompress_dotd/main.nf
+++ b/modules/local/decompress_dotd/main.nf
@@ -45,11 +45,11 @@ process DECOMPRESS {
         else
             if [ -f \$1 ]; then
                 case \$1 in
-                    *.tar.gz)    tar xvzf \$1 && tar dvf \$1 \$(basename \$1 .tar.gz) ;;
-                    *.gz)        gunzip \$1                                           ;;
-                    *.tar)       tar xvf \$1 && tar dvf \$1 \$(basename \$1 .tar)     ;;
-                    *.zip)       unzip \$1                                            ;;
-                    *)           echo "extract: '\$1' - unknown archive method"       ;;
+                    *.tar.gz)    tar xvzf \$1 && tar dvf \$1 \$(find . -type d -name '*[!.tar.gz]') ;;
+                    *.gz)        gunzip \$1                                                         ;;
+                    *.tar)       tar xvf \$1 && tar dvf \$1 \$(find . -type d -name '*[!.tar]')     ;;
+                    *.zip)       unzip \$1                                                          ;;
+                    *)           echo "extract: '\$1' - unknown archive method"                     ;;
                 esac
             else
                 echo "\$1 - file does not exist"


### PR DESCRIPTION
This PR adds a verification step to unpacking tar archives in the DECOMPRESS process, addressing #395. Specifically it:
1. Checks that all files in the archive are present when unpacked
2. Checks that all of the files are the same size.

The main reason for the PR being slightly more complicated than originally planned is that `tar d` will fail with exit code 0 if *anything* about a file has changed - including permissions and such. Given differences between the computing platform where the file may have been generated and where the workflow is executed, I think this is too strict.

I haven't included tests in the PR, put it seems to have worked well on a workflow I'm currently executing on ~7,000 input Bruker .d files.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
