### PR TITLE
Make files selected with `random_preanalysis` reproducible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#400](https://github.com/bigbio/quantms/pull/400) The random file selection when using `random_preanalysis` with DIANN is now reproducible.
 
-
 ### `Changed`
 
 ### `Fixed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#386](https://github.com/bigbio/quantms/pull/386) Make validation of ontology terms optional
 
 ### Fixed
+
 - [#400](https://github.com/bigbio/quantms/pull/400) The random file selection when using `random_preanalysis` with DIANN is now reproducible.
 
 ### `Changed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#386](https://github.com/bigbio/quantms/pull/386) Make validation of ontology terms optional
 
+### Fixed
+- [#400](https://github.com/bigbio/quantms/pull/400) The random file selection when using `random_preanalysis` with DIANN is now reproducible.
+
+
 ### `Changed`
 
 ### `Fixed`

--- a/nextflow.config
+++ b/nextflow.config
@@ -197,6 +197,7 @@ params {
     skip_preliminary_analysis    = false
     empirical_assembly_log       = null
     random_preanalysis           = false
+    random_preanalysis_seed      = 42
     empirical_assembly_ms_n      = 200
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1059,6 +1059,12 @@
                     "default": false,
                     "fa_icon": "far fa-check-square"
                 },
+                "random_preanalysis_seed": {
+                    "type": "integer",
+                    "description": "Set the random seed for the random selection of spectrum files to generate the empirical library.",
+                    "default": 42,
+                    "fa_icon": false
+                },
                 "empirical_assembly_ms_n": {
                     "type": "integer",
                     "description": "The number of randomly selected spectrum files.",

--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -78,7 +78,7 @@ workflow DIA {
         if (params.random_preanalysis) {
             preanalysis_subset = ch_file_preparation_results
                 .toSortedList()
-                .flatten()
+                .flatMap()
                 .randomSample(params.empirical_assembly_ms_n, params.random_preanalysis_seed)
             empirical_lib_files = preanalysis_subset
                 .map { result -> result[1] }

--- a/workflows/dia.nf
+++ b/workflows/dia.nf
@@ -76,9 +76,10 @@ workflow DIA {
         // MODULE: DIANN_PRELIMINARY_ANALYSIS
         //
         if (params.random_preanalysis) {
-            preanalysis_seed = 2024
             preanalysis_subset = ch_file_preparation_results
-                .randomSample(params.empirical_assembly_ms_n, preanalysis_seed)
+                .toSortedList()
+                .flatten()
+                .randomSample(params.empirical_assembly_ms_n, params.random_preanalysis_seed)
             empirical_lib_files = preanalysis_subset
                 .map { result -> result[1] }
                 .collect()


### PR DESCRIPTION
This PR adds a sorting step to the input channel prior to the random selection of files. It also adds a new parameter to control the random seed.

Fixes #399.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
