### PR TITLE
Fixed MSGF TMT MS3

### DIFF
--- a/modules/local/openms/isobaricanalyzer/main.nf
+++ b/modules/local/openms/isobaricanalyzer/main.nf
@@ -20,10 +20,10 @@ process ISOBARICANALYZER {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.mzml_id}"
 
-    if (meta.dissociationmethod == "HCD" || meta.dissociationmethod == "HCID") diss_meth = "auto"
-    else if (meta.dissociationmethod == "CID") diss_meth = "Collision-induced dissociation"
-    else if (meta.dissociationmethod == "ETD") diss_meth = "Electron transfer dissociation"
-    else if (meta.dissociationmethod == "ECD") diss_meth = "Electron capture dissociation"
+    if (params.quant_activation_method == "HCD" || params.quant_activation_method == "HCID") diss_meth = "auto"
+    else if (params.quant_activation_method == "CID") diss_meth = "Collision-induced dissociation"
+    else if (params.quant_activation_method == "ETD") diss_meth = "Electron transfer dissociation"
+    else if (params.quant_activation_method == "ECD") diss_meth = "Electron capture dissociation"
 
     def iso_normalization = params.iso_normalization ? "-quantification:normalization" : ""
     def isotope_correction = params.isotope_correction ? "-quantification:isotope_correction true" : "-quantification:isotope_correction false"

--- a/modules/local/openms/thirdparty/searchenginemsgf/main.nf
+++ b/modules/local/openms/thirdparty/searchenginemsgf/main.nf
@@ -78,6 +78,7 @@ process SEARCHENGINEMSGF {
         -min_peptide_length $params.min_peptide_length \\
         -max_peptide_length $params.max_peptide_length \\
         ${max_missed_cleavages} \\
+        -fragment_method $meta.dissociationmethod \\
         -isotope_error_range $params.isotope_error_range \\
         -enzyme "${enzyme}" \\
         -tryptic ${msgf_num_enzyme_termini} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -73,7 +73,7 @@ params {
     reference_channel           = '126'
     min_precursor_intensity     = 1.0
     reporter_mass_shift         = 0.002
-    select_activation           = 'HCD'
+    quant_activation_method     = 'HCD'
     iso_normalization           = false
     min_reporter_intensity      = 0.0
     min_precursor_purity        = 0.0
@@ -91,7 +91,7 @@ params {
     mod_localization              = 'Phospho (S),Phospho (T),Phospho (Y)'
     fragment_mass_tolerance       = 0.03
     fragment_mass_tolerance_unit  = 'Da'
-    fragment_method               = 'HCD' //currently unused. hard to find a good logic to beat the defaults
+    ms2_fragment_method           = 'HCD' //currently unused. hard to find a good logic to beat the defaults
     isotope_error_range           = '0,1'
     instrument                    = null //auto-determined from tolerances
     protocol                      = 'automatic' //'automatic', 'phospho', 'iTRAQ', 'iTRAQ_phospho', 'TMT', 'none'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -300,7 +300,7 @@
                     "fa_icon": "fas fa-tasks",
                     "help_text": "Specify which variable modifications should be applied to the database search (eg. '' or 'Oxidation (M)', see Unimod modifications\nin the style '({unimod name} ({optional term specificity} {optional origin})').\nAll possible modifications can be found in the restrictions mentioned in the command line documentation of e.g. [CometAdapter](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/TOPP_CometAdapter.html) (scroll down a bit for the complete set).\nMultiple variable modifications can be specified comma separated (e.g. 'Carbamidomethyl (C),Oxidation (M)').\nVariable modifications may or may not be found at matching amino acids for a peptide to be reported."
                 },
-                "fragment_method": {
+                "ms2_fragment_method": {
                     "type": "string",
                     "description": "The fragmentation method used during tandem MS. (MS/MS or MS2).",
                     "default": "HCD",
@@ -653,7 +653,7 @@
             "description": "Extracts and normalizes labeling information",
             "default": "",
             "properties": {
-                "select_activation": {
+                "quant_activation_method": {
                     "type": "string",
                     "description": "Operate only on MSn scans where any of its precursors features a certain activation method. Set to empty to disable.",
                     "fa_icon": "fas fa-font",

--- a/subworkflows/local/create_input_channel.nf
+++ b/subworkflows/local/create_input_channel.nf
@@ -101,7 +101,7 @@ def create_meta_channel(LinkedHashMap row, is_sdrf, enzymes, files, wrapper) {
     // for sdrf read from config file, without it, read from params
     if (is_sdrf.toString().toLowerCase().contains("false")) {
         meta.labelling_type             = params.labelling_type
-        meta.dissociationmethod         = params.fragment_method
+        meta.dissociationmethod         = params.ms2_fragment_method
         meta.fixedmodifications         = params.fixed_mods
         meta.variablemodifications      = params.variable_mods
         meta.precursormasstolerance     = params.precursor_mass_tolerance


### PR DESCRIPTION
<!--
# nf-core/quantms pull request

Many thanks for contributing to nf-core/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

This PR Addresses MSGF+ identified both MS2 and MS3 for TMT MS3 experiment. Because the MSGF+ filter spectra by `fragment_method` parameter. So I enable `fragment_method` parameter in MSGF+. This parameter can be from SDRF and config file.
Also  there is a `select_activation` parameter (default HCD auto) for IsobaricAnalyzer. The `fragment_method` should be CID, and `select_activation ` should be HCD if MS2 CID and MS3 HCD in TMT MS3 experiment. For other ms2 experiment, we only consider `fragment_method` and just set it up correctly.