### PR TITLE
avoid silent skipping of ConsensusID

### DIFF
--- a/subworkflows/local/dda_id.nf
+++ b/subworkflows/local/dda_id.nf
@@ -159,8 +159,9 @@ workflow DDA_ID {
         //
         ch_psmfdrcontrol     = Channel.empty()
         ch_consensus_results = Channel.empty()
-        if (params.search_engines.split(",").size() > 1) {
-            CONSENSUSID(ch_consensus_input.groupTuple(size: params.search_engines.split(",").size()))
+        // see comments in id.nf
+        if (params.search_engines.tokenize(",").unique().size() > 1) {
+            CONSENSUSID(ch_consensus_input.groupTuple(size: params.search_engines.tokenize(",").unique().size()))
             ch_software_versions = ch_software_versions.mix(CONSENSUSID.out.versions.ifEmpty(null))
             ch_psmfdrcontrol = CONSENSUSID.out.consensusids
             ch_psmfdrcontrol

--- a/subworkflows/local/id.nf
+++ b/subworkflows/local/id.nf
@@ -45,7 +45,7 @@ workflow ID {
     n_unique_search_engines = params.search_engines.tokenize(",").unique().size()
     if (n_unique_search_engines > 1) {
         // 'remainder: true' will keep remainders which do not match the specified size
-        // if the 'size' is not matched, an empty channel will be returned and 
+        // if the 'size' is not matched, an empty channel will be returned and
         // nothing will be run for the 'CONSENSUSID' process
         CONSENSUSID(PSMRESCORING.out.results.groupTuple(size: n_unique_search_engines))
         ch_software_versions = ch_software_versions.mix(CONSENSUSID.out.versions.ifEmpty(null))

--- a/subworkflows/local/id.nf
+++ b/subworkflows/local/id.nf
@@ -42,11 +42,12 @@ workflow ID {
     ch_psmfdrcontrol     = Channel.empty()
     ch_consensus_results = Channel.empty()
     // split returns String[], whereas tokenize returns a list, unique works on lists
-    if (params.search_engines.tokenize(",").unique().size() > 1) {
+    n_unique_search_engines = params.search_engines.tokenize(",").unique().size()
+    if (n_unique_search_engines > 1) {
         // 'remainder: true' will keep remainders which do not match the specified size
         // if the 'size' is not matched, an empty channel will be returned and 
         // nothing will be run for the 'CONSENSUSID' process
-        CONSENSUSID(PSMRESCORING.out.results.groupTuple(size: params.search_engines.tokenize(",").unique().size()))
+        CONSENSUSID(PSMRESCORING.out.results.groupTuple(size: n_unique_search_engines))
         ch_software_versions = ch_software_versions.mix(CONSENSUSID.out.versions.ifEmpty(null))
         ch_psmfdrcontrol = CONSENSUSID.out.consensusids
         ch_consensus_results = CONSENSUSID.out.consensusids

--- a/subworkflows/local/id.nf
+++ b/subworkflows/local/id.nf
@@ -41,8 +41,12 @@ workflow ID {
     //
     ch_psmfdrcontrol     = Channel.empty()
     ch_consensus_results = Channel.empty()
-    if (params.search_engines.split(",").size() > 1) {
-        CONSENSUSID(PSMRESCORING.out.results.groupTuple(size: params.search_engines.split(",").size()))
+    // split returns String[], whereas tokenize returns a list, unique works on lists
+    if (params.search_engines.tokenize(",").unique().size() > 1) {
+        // 'remainder: true' will keep remainders which do not match the specified size
+        // if the 'size' is not matched, an empty channel will be returned and 
+        // nothing will be run for the 'CONSENSUSID' process
+        CONSENSUSID(PSMRESCORING.out.results.groupTuple(size: params.search_engines.tokenize(",").unique().size()))
         ch_software_versions = ch_software_versions.mix(CONSENSUSID.out.versions.ifEmpty(null))
         ch_psmfdrcontrol = CONSENSUSID.out.consensusids
         ch_consensus_results = CONSENSUSID.out.consensusids

--- a/subworkflows/local/id.nf
+++ b/subworkflows/local/id.nf
@@ -42,7 +42,7 @@ workflow ID {
     ch_psmfdrcontrol     = Channel.empty()
     ch_consensus_results = Channel.empty()
     // split returns String[], whereas tokenize returns a list, unique works on lists
-    n_unique_search_engines = params.search_engines.tokenize(",").unique().size()
+    def n_unique_search_engines = params.search_engines.tokenize(",").unique().size()
     if (n_unique_search_engines > 1) {
         // 'remainder: true' will keep remainders which do not match the specified size
         // if the 'size' is not matched, an empty channel will be returned and

--- a/workflows/quantms.nf
+++ b/workflows/quantms.nf
@@ -102,6 +102,14 @@ workflow QUANTMS {
         ch_versions = ch_versions.mix(DECOYDATABASE.out.versions.ifEmpty(null))
     }
 
+    // Check that there is no duplicated search engines
+    if (params.search_engines) {
+        search_engines = params.search_engines.tokenize(',')
+        if (search_engines.size() != search_engines.unique().size()) {
+            error( "Duplicated search engines in the search_engines parameter: ${params.search_engines}" )
+        }
+    }
+
     // Only performing id_only subworkflows .
     if (params.id_only) {
         DDA_ID( FILE_PREPARATION.out.results, ch_searchengine_in_db, FILE_PREPARATION.out.spectrum_data, CREATE_INPUT_CHANNEL.out.ch_expdesign)


### PR DESCRIPTION
### **User description**
- add check to not fail silently on duplicated search engine entries
- for safety: remove duplicated entries in search engine (not really needed, but in case check is missing it if a new workflow)

- document option of 'remainder: true' in a comment

## PR checklist

- [x] This comment contains a description of changes (with reason).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added error handling for duplicated search engine entries.

- Replaced `split` with `tokenize` and `unique` for better validation.

- Documented the use of `remainder: true` in comments.

- Enhanced workflow logic to prevent silent failures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dda_id.nf</strong><dd><code>Enhanced search engine validation in DDA_ID workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

subworkflows/local/dda_id.nf

<li>Replaced <code>split</code> with <code>tokenize</code> and <code>unique</code> for search engine validation.<br> <li> Updated logic to handle unique search engine entries.<br> <li> Improved error prevention in the <code>CONSENSUSID</code> process.


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/501/files#diff-34e6542a20cfb67b40b5a23a51e9cb0d15d33af527995483569fa639e08a3676">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>id.nf</strong><dd><code>Improved search engine validation in ID workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

subworkflows/local/id.nf

<li>Replaced <code>split</code> with <code>tokenize</code> and <code>unique</code> for search engine validation.<br> <li> Added comments explaining <code>remainder: true</code> behavior.<br> <li> Improved logic to handle unique search engine entries.


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/501/files#diff-2a0f4d51e58cbc070bc68c0b2b2782142f3f083a9c68a688cd4743850611a566">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quantms.nf</strong><dd><code>Added error handling for duplicated search engines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workflows/quantms.nf

<li>Added error handling for duplicated search engine entries.<br> <li> Validated <code>search_engines</code> parameter using <code>tokenize</code> and <code>unique</code>.<br> <li> Prevented silent failures by throwing errors for duplicates.


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/501/files#diff-b21f863ae27419af87d32d9269e812fafe81f1718c522a0248a00d06d9396285">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>