### PR TITLE
move documentation to separate repository

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, daichengxin, jpfeuffer, timosachenberg, ypriverol'
 author = 'daichengxin, jpfeuffer, timosachenberg, ypriverol'
 
 # The full version, including alpha/beta/rc tags
-release = '1.3.0'
+release = '1.4.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
### **User description**
The website was built directly from this project, but as it was on a single branch, separate from the main branch, it was moved to a new repository:

- https://github.com/bigbio/quantms-readthedocs
- readthedocs-project: https://app.readthedocs.org/projects/quantms-readthedocs/


old readthedocs project: https://quantms--527.org.readthedocs.build/en/527/


___

### **PR Type**
enhancement

