### PR TITLE
Small patch with DIA precursor and fragment masses limits.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -104,10 +104,10 @@ params {
     num_hits                      = 1
     max_mods                      = 3
     min_peaks                     = 10 //minimum number of peaks in a spectrum
-    min_pr_mz                     = null
-    max_pr_mz                     = null
-    min_fr_mz                     = null
-    max_fr_mz                     = null
+    min_pr_mz                     = 400
+    max_pr_mz                     = 2400
+    min_fr_mz                     = 100
+    max_fr_mz                     = 1800
 
     // MSRESCORE flags
     ms2rescore                      = false


### PR DESCRIPTION
### **User description**
Small patch with DIA precursor and fragment masses limits.

<!--
# bigbio/quantms pull request

Many thanks for contributing to bigbio/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


___

### **PR Type**
Enhancement


___

### **Description**
- Set default mass range limits for DIA precursor and fragment ions

- Configure precursor m/z range from 400 to 2400

- Configure fragment m/z range from 100 to 1800

- Replace null values with specific mass limits


___

### **Changes diagram**

```mermaid
flowchart LR
  A["DIA Configuration"] --> B["Precursor m/z: 400-2400"]
  A --> C["Fragment m/z: 100-1800"]
  B --> D["Mass Filtering"]
  C --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nextflow.config</strong><dd><code>Configure DIA mass range parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nextflow.config

<li>Set <code>min_pr_mz</code> from null to 400<br> <li> Set <code>max_pr_mz</code> from null to 2400<br> <li> Set <code>min_fr_mz</code> from null to 100<br> <li> Set <code>max_fr_mz</code> from null to 1800


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/564/files#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4ea">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>