### PR TITLE
fixed rescoring range bugs

### DIFF
--- a/modules/local/openms/id_ripper/main.nf
+++ b/modules/local/openms/id_ripper/main.nf
@@ -8,12 +8,11 @@ process ID_RIPPER {
         'ghcr.io/bigbio/openms-tools-thirdparty:2025.04.14' }"
 
     input:
-    tuple val(meta), path(id_file), val(qval_score)
+    tuple val(meta), path(id_file)
 
     output:
     val(meta), emit: meta
     path("*.idXML"), emit: id_rippers
-    val("MS:1001491"), emit: qval_score
     path "versions.yml", emit: versions
     path "*.log", emit: log
 

--- a/subworkflows/local/dda_id/main.nf
+++ b/subworkflows/local/dda_id/main.nf
@@ -106,7 +106,7 @@ workflow DDA_ID {
             ch_file_preparation_results.map{[it[0].mzml_id, it[0]]}.set{meta}
             ID_RIPPER.out.id_rippers.flatten().map { add_file_prefix (it)}.set{id_rippers}
             meta.combine(id_rippers, by: 0)
-                    .map{ [it[1], it[2], "MS:1001491"]}
+                    .map{ [it[1], it[2]]}
                     .set{ ch_consensus_input }
             ch_software_versions = ch_software_versions.mix(ID_RIPPER.out.versions)
 
@@ -137,7 +137,7 @@ workflow DDA_ID {
             ch_file_preparation_results.map{[it[0].mzml_id, it[0]]}.set{meta}
             ID_RIPPER.out.id_rippers.flatten().map { add_file_prefix (it)}.set{id_rippers}
             meta.combine(id_rippers, by: 0)
-                    .map{ [it[1], it[2], "MS:1001491"]}
+                    .map{ [it[1], it[2]]}
                     .set{ ch_consensus_input }
             ch_software_versions = ch_software_versions.mix(ID_RIPPER.out.versions)
 

--- a/subworkflows/local/psm_rescoring/main.nf
+++ b/subworkflows/local/psm_rescoring/main.nf
@@ -80,7 +80,7 @@ workflow PSM_RESCORING {
         ch_file_preparation_results.map{[it[0].mzml_id, it[0]]}.set{meta}
         ID_RIPPER.out.id_rippers.flatten().map { add_file_prefix (it)}.set{id_rippers}
         meta.combine(id_rippers, by: 0)
-                .map{ [it[1], it[2], "MS:1001491"]}
+                .map{ [it[1], it[2]]}
                 .set{ ch_consensus_input }
         ch_software_versions = ch_software_versions.mix(ID_RIPPER.out.versions)
 
@@ -111,7 +111,7 @@ workflow PSM_RESCORING {
         ch_file_preparation_results.map{[it[0].mzml_id, it[0]]}.set{meta}
         ID_RIPPER.out.id_rippers.flatten().map { add_file_prefix (it)}.set{id_rippers}
         meta.combine(id_rippers, by: 0)
-                .map{ [it[1], it[2], "MS:1001491"]}
+                .map{ [it[1], it[2]]}
                 .set{ ch_consensus_input }
         ch_software_versions = ch_software_versions.mix(ID_RIPPER.out.versions)
     }


### PR DESCRIPTION
### **User description**
<!--
# bigbio/quantms pull request

Many thanks for contributing to bigbio/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


___

### **PR Type**
Bug fix


___

### **Description**
- Remove hardcoded qval_score parameter from ID_RIPPER module

- Fix channel mapping in rescoring workflows

- Simplify data flow by removing unnecessary score parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ID_RIPPER module"] --> B["Remove qval_score input/output"]
  B --> C["Update channel mapping"]
  C --> D["Fix DDA_ID workflow"]
  C --> E["Fix PSM_RESCORING workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.nf</strong><dd><code>Remove qval_score parameter from ID_RIPPER</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/local/openms/id_ripper/main.nf

<ul><li>Remove <code>qval_score</code> parameter from input tuple<br> <li> Remove <code>qval_score</code> output emission<br> <li> Simplify module interface</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/583/files#diff-2ddd6a12a4c651ad32bc5bd21fabc5e7cef47c14f588e1fcc6aa0803b19c163a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.nf</strong><dd><code>Fix channel mapping in DDA_ID workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

subworkflows/local/dda_id/main.nf

<ul><li>Remove hardcoded "MS:1001491" from channel mapping<br> <li> Fix tuple structure in consensus input channel<br> <li> Apply changes to both rescoring range conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/583/files#diff-e59f6e1c770ca3e1ed65d304058b74a2cec4621ad80e8523e8a199867b628cd5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.nf</strong><dd><code>Fix channel mapping in PSM_RESCORING workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

subworkflows/local/psm_rescoring/main.nf

<ul><li>Remove hardcoded "MS:1001491" from channel mapping<br> <li> Fix tuple structure in consensus input channel<br> <li> Apply changes to both rescoring range conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/583/files#diff-3e19838b4df92c18e77f7d9a874c014b9471216b264a1cda76989c9175b43354">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

