### PR TITLE
small changes for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [627](https://github.com/bigbio/quantms/pull/627) Move thermorawfileparser from local to bigbio nf-core
 - [629](https://github.com/bigbio/quantms/pull/629) Update quantms-rescoring to 0.0.13 to support transfer learning
 - [615](https://github.com/bigbio/quantms/pull/615) Update quantms-utils 0.0.24 and pmultiqc 0.0.39
+- [614](https://github.com/bigbio/quantms/pull/614) enable_diann_mztab from true to false as default. For DIA pipelines the mzTab will not be generated unless specified by a parameter `--enable_diann_mztab true`. 
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [627](https://github.com/bigbio/quantms/pull/627) Move thermorawfileparser from local to bigbio nf-core
 - [629](https://github.com/bigbio/quantms/pull/629) Update quantms-rescoring to 0.0.13 to support transfer learning
 - [615](https://github.com/bigbio/quantms/pull/615) Update quantms-utils 0.0.24 and pmultiqc 0.0.39
-- [614](https://github.com/bigbio/quantms/pull/614) enable_diann_mztab from true to false as default. For DIA pipelines the mzTab will not be generated unless specified by a parameter `--enable_diann_mztab true`. 
+- [614](https://github.com/bigbio/quantms/pull/614) enable_diann_mztab from true to false as default. For DIA pipelines the mzTab will not be generated unless specified by a parameter `--enable_diann_mztab true`.
+- [635](https://github.com/bigbio/quantms/pull/635) Minimum Nextflow version requirement updated to `>=25.04.0`
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated pyonsite==0.0.2
 - Updated quantms-utils==0.0.24
 
+### `Deprecations`
+
+- [626](https://github.com/bigbio/quantms/pull/626) Removed luciphor-specific parameters: `luciphor_neutral_losses`, `luciphor_decoy_mass`, `luciphor_decoy_neutral_losses`. These have been replaced with onsite parameters: `onsite_neutral_losses`, `onsite_decoy_mass`, `onsite_decoy_neutral_losses`. The new onsite module provides support for multiple PTM localization algorithms (AScore, PhosphoRS, and LucXor) with unified parameter naming.
+
 ## [1.6.0] bigbio/quantms - [13/08/2025] - Munich
 
 ### `Added`

--- a/modules/local/utils/msrescore_features/main.nf
+++ b/modules/local/utils/msrescore_features/main.nf
@@ -51,10 +51,10 @@ process MSRESCORE_FEATURES {
         if (meta['fragmentmasstoleranceunit'].toLowerCase().endsWith('da')) {
             ms2_tolerance = meta['fragmentmasstolerance']
         } else if (params.ms2features_tolerance_unit == 'ppm') {
-            log.info "Warning: MS2pip only supports Da unit. Using default from config!"
+            log.warn "Warning: MS2pip only supports Da unit. Using default from config!"
             ms2_tolerance = 0.05
         } else {
-            log.info "Warning: MS2pip only supports Da unit. Using default from config!"
+            log.warn "Warning: MS2pip only supports Da unit. Using default from config!"
         }
     }
 

--- a/modules/local/utils/msrescore_features/main.nf
+++ b/modules/local/utils/msrescore_features/main.nf
@@ -48,13 +48,15 @@ process MSRESCORE_FEATURES {
         // ms2pip only supports Da unit
         ms2_tolerance_unit = 'Da'
         ms2_tolerance = params.ms2features_tolerance
-        if (meta['fragmentmasstoleranceunit'].toLowerCase().endsWith('da')) {
+        def fragment_unit_lower = meta['fragmentmasstoleranceunit'].toLowerCase()
+        if (fragment_unit_lower.endsWith('da')) {
             ms2_tolerance = meta['fragmentmasstolerance']
-        } else if (params.ms2features_tolerance_unit == 'ppm') {
+        } else if (fragment_unit_lower == 'ppm' || params.ms2features_tolerance_unit == 'ppm') {
             log.warn "Warning: MS2pip only supports Da unit. Using default from config!"
-            ms2_tolerance = 0.05
+            ms2_tolerance = params.ms2features_tolerance
         } else {
-            log.warn "Warning: MS2pip only supports Da unit. Using default from config!"
+            log.warn "Warning: MS2pip only supports Da unit. Fragment mass tolerance unit '${meta['fragmentmasstoleranceunit']}' is not supported. Using default from config! In the future, please use 'Da' or 'ppm'."
+            ms2_tolerance = params.ms2features_tolerance
         }
     }
 


### PR DESCRIPTION
### **User description**
<!--
# bigbio/quantms pull request

Many thanks for contributing to bigbio/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Change logging level from info to warn for MS2pip warnings

- Update CHANGELOG with DIA pipeline mzTab default parameter change

- Document deprecation of luciphor parameters in favor of onsite

- Add entries for recent pipeline updates and improvements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logging Changes"] -->|info to warn| B["MS2pip Warnings"]
  C["CHANGELOG Updates"] -->|Added| D["DIA mzTab Default"]
  C -->|Added| E["Deprecations Section"]
  E -->|luciphor params| F["onsite params"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.nf</strong><dd><code>Upgrade MS2pip warnings to warn level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/local/utils/msrescore_features/main.nf

<ul><li>Changed <code>log.info</code> to <code>log.warn</code> for MS2pip unit compatibility warnings<br> <li> Improves log severity classification for warning messages<br> <li> Two instances updated in conditional branches</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/635/files#diff-462941b55bbfefde8d4296ad1bda4414af36ebd2ef2e79580aac54833ca2da38">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document parameter changes and deprecations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry for PR #614 documenting DIA pipeline mzTab default <br>parameter change<br> <li> Created new "Deprecations" section documenting removal of <br>luciphor-specific parameters<br> <li> Documented replacement with unified onsite parameters for PTM <br>localization<br> <li> Clarifies migration path for users from luciphor to onsite module</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/quantms/pull/635/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

