### PR TITLE
Resolve quantms issue 650 - remove unnecesary params, present in SDRF

### DIFF
--- a/conf/tests/test_lfq.config
+++ b/conf/tests/test_lfq.config
@@ -25,7 +25,6 @@ params {
     outdir = "./results_lfq"
 
     // Input data
-    labelling_type = "label free sample"
     input = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/refs/heads/quantms/testdata/lfq_ci/BSA/BSA_design.sdrf.tsv'
     database = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/lfq_ci/BSA/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta'
     search_engines = "comet,sage"
@@ -33,7 +32,6 @@ params {
     add_triqler_output = true
     protein_level_fdr_cutoff = 1.0
     psm_level_fdr_cutoff = 1.0
-    acquisition_method = "dda"
     quantify_decoys = true
     mzml_features = true
 }

--- a/conf/tests/test_lfq_sage.config
+++ b/conf/tests/test_lfq_sage.config
@@ -26,18 +26,14 @@ params {
     tracedir = "${params.outdir}/pipeline_info"
 
     // Input data
-    labelling_type = "label free sample"
     input = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/lfq_ci/BSA/BSA_design_urls.tsv'
     database = 'https://raw.githubusercontent.com/bigbio/quantms-test-datasets/quantms/testdata/lfq_ci/BSA/18Protein_SoCe_Tr_detergents_trace.fasta'
     add_decoys = true
     search_engines = "sage,comet"
-    precursor_mass_tolerance = 20
-    fragment_mass_tolerance = 0.1
     decoy_string= "rev"
     add_triqler_output = true
     protein_level_fdr_cutoff = 1.0
     psm_level_fdr_cutoff = 1.0
     run_fdr_cutoff = 0.5
-    acquisition_method = "dda"
     quantify_decoys = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,8 +82,13 @@ params {
     met_excision                  = true // Met-excision is enabled by default
     num_enzyme_termini            = 'fully'
     allowed_missed_cleavages      = 2
+    precursor_mass_tolerance      = 5
+    precursor_mass_tolerance_unit = 'ppm'
+    variable_mods                 = 'Oxidation (M)'
     enable_mod_localization       = false
     mod_localization              = 'Phospho (S),Phospho (T),Phospho (Y)'
+    fragment_mass_tolerance       = 0.03
+    fragment_mass_tolerance_unit  = 'Da'
     ms2_fragment_method           = 'HCD' //currently unused. hard to find a good logic to beat the defaults
     isotope_error_range           = '0,1'
     instrument                    = null //auto-determined from tolerances

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,6 @@ params {
     root_folder        = null
     local_input_type   = 'mzML'
     database           = null
-    acquisition_method = null
     id_only            = false
 
     // Input options and validation of sdrf files
@@ -67,7 +66,6 @@ params {
     mzml_features         = false
 
     // Isobaric analyses
-    labelling_type              = null
     isotope_correction          = false // Disable plex isotope correction
     plex_corr_matrix_file       = null // Path to the correction matrix file if disable isotope correction is true
 
@@ -81,18 +79,11 @@ params {
     precursor_isotope_deviation = 10.0
 
     // shared search engine parameters
-    enzyme                        = 'Trypsin'
     met_excision                  = true // Met-excision is enabled by default
     num_enzyme_termini            = 'fully'
     allowed_missed_cleavages      = 2
-    precursor_mass_tolerance      = 5
-    precursor_mass_tolerance_unit = 'ppm'
-    fixed_mods                    = 'Carbamidomethyl (C)'
-    variable_mods                 = 'Oxidation (M)'
     enable_mod_localization       = false
     mod_localization              = 'Phospho (S),Phospho (T),Phospho (Y)'
-    fragment_mass_tolerance       = 0.03
-    fragment_mass_tolerance_unit  = 'Da'
     ms2_fragment_method           = 'HCD' //currently unused. hard to find a good logic to beat the defaults
     isotope_error_range           = '0,1'
     instrument                    = null //auto-determined from tolerances

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -19,7 +19,7 @@
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.(?:csv|tsv|sdrf)$",
                     "description": "URI/path to an SDRF file in SDRF format with .sdrf, .tsv, or .csv extension. For more info see help text or docs.",
-                    "help_text": "Input is specified by using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and annotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). Input files will be downloaded and cached from the URIs specified in the SDRF file.\n\nThe SDRF file can have .sdrf, .tsv, or .csv extensions. An OpenMS-style experimental design will be generated based on the factor columns of the SDRF. The settings for the following parameters will currently be overwritten by the ones specified in the SDRF:\n\n    * `fixed_mods`,\n    * `variable_mods`,\n    * `precursor_mass_tolerance`,\n    * `precursor_mass_tolerance_unit`,\n    * `fragment_mass_tolerance`,\n    * `fragment_mass_tolerance_unit`,\n    * `fragment_method`,\n    * `enzyme`",
+                    "help_text": "Input is specified by using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and annotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). Input files will be downloaded and cached from the URIs specified in the SDRF file.\n\nThe SDRF file can have .sdrf, .tsv, or .csv extensions. An OpenMS-style experimental design will be generated based on the factor columns of the SDRF. The following parameters are read exclusively from the SDRF file:\n\n    * `acquisition_method` (from 'Proteomics Data Acquisition Method' column),\n    * `labelling_type` (from 'Label' column),\n    * `fixed_mods` (from 'FixedModifications' column),\n    * `variable_mods` (from 'VariableModifications' column),\n    * `precursor_mass_tolerance` (from 'PrecursorMassTolerance' column),\n    * `precursor_mass_tolerance_unit` (from 'PrecursorMassToleranceUnit' column),\n    * `fragment_mass_tolerance` (from 'FragmentMassTolerance' column),\n    * `fragment_mass_tolerance_unit` (from 'FragmentMassToleranceUnit' column),\n    * `enzyme` (from 'Enzyme' column)",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "outdir": {
@@ -53,12 +53,6 @@
                     "fa_icon": "fas fa-file-invoice",
                     "default": "mzML",
                     "help_text": "If the above [`--root_folder`](#root_folder) was given to load local input files, this overwrites the file type/extension of\nthe filename as specified in the SDRF. Usually used in case you have an mzML-converted version of the files already. Needs to be\none of 'mzML', 'raw', 'd', or 'dia' (the letter cases should match your files exactly). Compressed variants (.gz, .tar, .tar.gz, .zip) are supported for 'mzML', 'raw', and 'd' formats."
-                },
-                "acquisition_method": {
-                    "type": "string",
-                    "description": "Proteomics data acquisition method",
-                    "enum": ["dda", "dia"],
-                    "fa_icon": "far fa-list-ol"
                 },
                 "id_only": {
                     "type": "boolean",
@@ -248,13 +242,6 @@
                     "fa_icon": "fas fa-sliders-h",
                     "help_text": "Since sage's runtime benefits from building an index only once per database and processing files in parallel, you can choose the number of sage processes to be spawned here. Input mzMLs will be distributed equally among them in arbitrary order."
                 },
-                "enzyme": {
-                    "type": "string",
-                    "description": "The enzyme to be used for in-silico digestion, in 'OpenMS format'",
-                    "default": "Trypsin",
-                    "fa_icon": "fas fa-list-ol",
-                    "help_text": "Specify which enzymatic restriction should be applied, e.g. 'unspecific cleavage', 'Trypsin' (default), see OpenMS\n[enzymes](https://github.com/OpenMS/OpenMS/blob/develop/share/OpenMS/CHEMISTRY/Enzymes.xml). Note: MSGF does not support extended\ncutting rules, as used by default with `Trypsin`. I.e. if you specify `Trypsin` with MSGF, it will be automatically converted to\n`Trypsin/P`= 'Trypsin without proline rule'."
-                },
                 "met_excision": {
                     "type": "boolean",
                     "description": "Database searches accounted for N-terminal methionine excision, a common co-translational modification where the initial methionine is enzymatically removed from proteins.",
@@ -275,48 +262,6 @@
                     "description": "Specify the maximum number of allowed missed enzyme cleavages in a peptide. The parameter is not applied if `unspecific cleavage` is specified as enzyme.",
                     "default": 2,
                     "fa_icon": "fas fa-sliders-h"
-                },
-                "precursor_mass_tolerance": {
-                    "type": "integer",
-                    "description": "Precursor mass tolerance used for database search. For High-Resolution instruments a precursor mass tolerance value of 5 ppm is recommended (i.e. 5). See also [`--precursor_mass_tolerance_unit`](#precursor_mass_tolerance_unit).",
-                    "default": 5,
-                    "fa_icon": "fas fa-sliders-h"
-                },
-                "precursor_mass_tolerance_unit": {
-                    "type": "string",
-                    "description": "Precursor mass tolerance unit used for database search. Possible values are 'ppm' (default) and 'Da'.",
-                    "default": "ppm",
-                    "fa_icon": "fas fa-sliders-h",
-                    "enum": ["Da", "ppm"]
-                },
-                "fragment_mass_tolerance": {
-                    "type": "number",
-                    "description": "Fragment mass tolerance used for database search. The default of 0.03 Da is for high-resolution instruments.",
-                    "default": 0.03,
-                    "fa_icon": "fas fa-sliders-h",
-                    "help_text": "Caution: for Comet we are estimating the `fragment_bin_tolerance` parameter based on this automatically."
-                },
-                "fragment_mass_tolerance_unit": {
-                    "type": "string",
-                    "description": "Fragment mass tolerance unit used for database search. Possible values are 'ppm' (default) and 'Da'.",
-                    "default": "Da",
-                    "fa_icon": "fas fa-list-ol",
-                    "help_text": "Caution: for Comet we are estimating the `fragment_bin_tolerance` parameter based on this automatically.",
-                    "enum": ["Da", "ppm"]
-                },
-                "fixed_mods": {
-                    "type": "string",
-                    "description": "A comma-separated list of fixed modifications with their Unimod name to be searched during database search",
-                    "default": "Carbamidomethyl (C)",
-                    "fa_icon": "fas fa-tasks",
-                    "help_text": "Specify which fixed modifications should be applied to the database search (eg. '' or 'Carbamidomethyl (C)', see Unimod modifications\nin the style '({unimod name} ({optional term specificity} {optional origin})').\nAll possible modifications can be found in the restrictions mentioned in the command line documentation of e.g. [CometAdapter](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/TOPP_CometAdapter.html) (scroll down a bit for the complete set).\nMultiple fixed modifications can be specified comma separated (e.g. 'Carbamidomethyl (C),Oxidation (M)').\nFixed modifications need to be found at every matching amino acid for a peptide to be reported."
-                },
-                "variable_mods": {
-                    "type": "string",
-                    "description": "A comma-separated list of variable modifications with their Unimod name to be searched during database search",
-                    "default": "Oxidation (M)",
-                    "fa_icon": "fas fa-tasks",
-                    "help_text": "Specify which variable modifications should be applied to the database search (eg. '' or 'Oxidation (M)', see Unimod modifications\nin the style '({unimod name} ({optional term specificity} {optional origin})').\nAll possible modifications can be found in the restrictions mentioned in the command line documentation of e.g. [CometAdapter](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/TOPP_CometAdapter.html) (scroll down a bit for the complete set).\nMultiple variable modifications can be specified comma separated (e.g. 'Carbamidomethyl (C),Oxidation (M)').\nVariable modifications may or may not be found at matching amino acids for a peptide to be reported."
                 },
                 "ms2_fragment_method": {
                     "type": "string",
@@ -998,21 +943,6 @@
             "description": "General protein quantification settings for both LFQ and isobaric labelling.",
             "default": "",
             "properties": {
-                "labelling_type": {
-                    "type": "string",
-                    "description": "Specify the labelling method that was used. Will be ignored if SDRF was given but is mandatory otherwise",
-                    "fa_icon": "fas fa-font",
-                    "help_text": "Quantification method used in the experiment.",
-                    "enum": [
-                        "label free sample",
-                        "itraq4plex",
-                        "itraq8plex",
-                        "tmt6plex",
-                        "tmt10plex",
-                        "tmt11plex",
-                        "tmt16plex"
-                    ]
-                },
                 "top": {
                     "type": "integer",
                     "description": "Calculate protein abundance from this number of proteotypic peptides (most abundant first; '0' for all, Default 3)",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -19,7 +19,7 @@
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.(?:csv|tsv|sdrf)$",
                     "description": "URI/path to an SDRF file in SDRF format with .sdrf, .tsv, or .csv extension. For more info see help text or docs.",
-                    "help_text": "Input is specified by using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and annotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). Input files will be downloaded and cached from the URIs specified in the SDRF file.\n\nThe SDRF file can have .sdrf, .tsv, or .csv extensions. An OpenMS-style experimental design will be generated based on the factor columns of the SDRF. The following parameters are read exclusively from the SDRF file:\n\n    * `acquisition_method` (from 'Proteomics Data Acquisition Method' column),\n    * `labelling_type` (from 'Label' column),\n    * `fixed_mods` (from 'FixedModifications' column),\n    * `variable_mods` (from 'VariableModifications' column),\n    * `precursor_mass_tolerance` (from 'PrecursorMassTolerance' column),\n    * `precursor_mass_tolerance_unit` (from 'PrecursorMassToleranceUnit' column),\n    * `fragment_mass_tolerance` (from 'FragmentMassTolerance' column),\n    * `fragment_mass_tolerance_unit` (from 'FragmentMassToleranceUnit' column),\n    * `enzyme` (from 'Enzyme' column)",
+                    "help_text": "Input is specified by using a path or URI to a PRIDE Sample to Data Relation Format file (SDRF), e.g. as part of a submitted and annotated PRIDE experiment (see [here](https://github.com/bigbio/proteomics-metadata-standard/tree/master/annotated-projects) for examples). Input files will be downloaded and cached from the URIs specified in the SDRF file.\n\nThe SDRF file can have .sdrf, .tsv, or .csv extensions. An OpenMS-style experimental design will be generated based on the factor columns of the SDRF.\n\nThe following parameters are read **exclusively** from the SDRF file (required columns):\n\n    * `acquisition_method` (from 'Proteomics Data Acquisition Method' column),\n    * `labelling_type` (from 'Label' column),\n    * `enzyme` (from 'Enzyme' column),\n    * `fixed_mods` (from 'FixedModifications' column)\n\nThe following parameters are read from SDRF but can be **overridden via command line**:\n\n    * `precursor_mass_tolerance` (from 'PrecursorMassTolerance' column),\n    * `precursor_mass_tolerance_unit` (from 'PrecursorMassToleranceUnit' column),\n    * `fragment_mass_tolerance` (from 'FragmentMassTolerance' column),\n    * `fragment_mass_tolerance_unit` (from 'FragmentMassToleranceUnit' column),\n    * `variable_mods` (from 'VariableModifications' column)",
                     "fa_icon": "fas fa-file-csv"
                 },
                 "outdir": {
@@ -262,6 +262,43 @@
                     "description": "Specify the maximum number of allowed missed enzyme cleavages in a peptide. The parameter is not applied if `unspecific cleavage` is specified as enzyme.",
                     "default": 2,
                     "fa_icon": "fas fa-sliders-h"
+                },
+                "precursor_mass_tolerance": {
+                    "type": "integer",
+                    "description": "Precursor mass tolerance used for database search. For High-Resolution instruments a precursor mass tolerance value of 5 ppm is recommended (i.e. 5). See also [`--precursor_mass_tolerance_unit`](#precursor_mass_tolerance_unit).",
+                    "default": 5,
+                    "fa_icon": "fas fa-sliders-h",
+                    "help_text": "This value can be overridden via command line. If not specified, the value from the SDRF file will be used."
+                },
+                "precursor_mass_tolerance_unit": {
+                    "type": "string",
+                    "description": "Precursor mass tolerance unit used for database search. Possible values are 'ppm' (default) and 'Da'.",
+                    "default": "ppm",
+                    "fa_icon": "fas fa-sliders-h",
+                    "enum": ["Da", "ppm"],
+                    "help_text": "This value can be overridden via command line. If not specified, the value from the SDRF file will be used."
+                },
+                "fragment_mass_tolerance": {
+                    "type": "number",
+                    "description": "Fragment mass tolerance used for database search. The default of 0.03 Da is for high-resolution instruments.",
+                    "default": 0.03,
+                    "fa_icon": "fas fa-sliders-h",
+                    "help_text": "Caution: for Comet we are estimating the `fragment_bin_tolerance` parameter based on this automatically. This value can be overridden via command line. If not specified, the value from the SDRF file will be used."
+                },
+                "fragment_mass_tolerance_unit": {
+                    "type": "string",
+                    "description": "Fragment mass tolerance unit used for database search. Possible values are 'ppm' and 'Da' (default).",
+                    "default": "Da",
+                    "fa_icon": "fas fa-list-ol",
+                    "help_text": "Caution: for Comet we are estimating the `fragment_bin_tolerance` parameter based on this automatically. This value can be overridden via command line. If not specified, the value from the SDRF file will be used.",
+                    "enum": ["Da", "ppm"]
+                },
+                "variable_mods": {
+                    "type": "string",
+                    "description": "A comma-separated list of variable modifications with their Unimod name to be searched during database search",
+                    "default": "Oxidation (M)",
+                    "fa_icon": "fas fa-tasks",
+                    "help_text": "Specify which variable modifications should be applied to the database search (eg. '' or 'Oxidation (M)', see Unimod modifications in the style '({unimod name} ({optional term specificity} {optional origin})'). All possible modifications can be found in the restrictions mentioned in the command line documentation of e.g. [CometAdapter](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/TOPP_CometAdapter.html). Multiple variable modifications can be specified comma separated (e.g. 'Carbamidomethyl (C),Oxidation (M)'). This value can be overridden via command line. If not specified, the value from the SDRF file will be used."
                 },
                 "ms2_fragment_method": {
                     "type": "string",

--- a/subworkflows/local/create_input_channel/main.nf
+++ b/subworkflows/local/create_input_channel/main.nf
@@ -107,6 +107,58 @@ def create_meta_channel(LinkedHashMap row, enzymes, files, wrapper) {
     }
 
     wrapper.acquisition_method = meta.acquisition_method
+
+    // Validate required SDRF columns - these parameters are now exclusively read from SDRF
+    def requiredColumns = [
+        'Label': row.Label,
+        'Enzyme': row.Enzyme,
+        'PrecursorMassTolerance': row.PrecursorMassTolerance,
+        'PrecursorMassToleranceUnit': row.PrecursorMassToleranceUnit,
+        'FragmentMassTolerance': row.FragmentMassTolerance,
+        'FragmentMassToleranceUnit': row.FragmentMassToleranceUnit,
+        'FixedModifications': row.FixedModifications,
+        'VariableModifications': row.VariableModifications
+    ]
+
+    def missingColumns = []
+    requiredColumns.each { colName, colValue ->
+        if (colValue == null || colValue.toString().trim().isEmpty()) {
+            missingColumns.add(colName)
+        }
+    }
+
+    if (missingColumns.size() > 0) {
+        log.error("ERROR: Missing or empty required SDRF columns for file '${filestr}': ${missingColumns.join(', ')}")
+        log.error("These parameters must be specified in the SDRF file. Please check your SDRF annotation.")
+        exit(1)
+    }
+
+    // Validate tolerance values are valid numbers
+    try {
+        Double.parseDouble(row.PrecursorMassTolerance)
+    } catch (NumberFormatException e) {
+        log.error("ERROR: Invalid PrecursorMassTolerance value '${row.PrecursorMassTolerance}' for file '${filestr}'. Must be a valid number.")
+        exit(1)
+    }
+
+    try {
+        Double.parseDouble(row.FragmentMassTolerance)
+    } catch (NumberFormatException e) {
+        log.error("ERROR: Invalid FragmentMassTolerance value '${row.FragmentMassTolerance}' for file '${filestr}'. Must be a valid number.")
+        exit(1)
+    }
+
+    // Validate tolerance units
+    def validUnits = ['ppm', 'da', 'Da', 'PPM']
+    if (!validUnits.any { row.PrecursorMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
+        log.error("ERROR: Invalid PrecursorMassToleranceUnit '${row.PrecursorMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
+        exit(1)
+    }
+    if (!validUnits.any { row.FragmentMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
+        log.error("ERROR: Invalid FragmentMassToleranceUnit '${row.FragmentMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
+        exit(1)
+    }
+
     meta.labelling_type = row.Label
     meta.fixedmodifications = row.FixedModifications
     meta.variablemodifications = row.VariableModifications

--- a/subworkflows/local/create_input_channel/main.nf
+++ b/subworkflows/local/create_input_channel/main.nf
@@ -108,16 +108,11 @@ def create_meta_channel(LinkedHashMap row, enzymes, files, wrapper) {
 
     wrapper.acquisition_method = meta.acquisition_method
 
-    // Validate required SDRF columns - these parameters are now exclusively read from SDRF
+    // Validate required SDRF columns - these parameters are exclusively read from SDRF (no command-line override)
     def requiredColumns = [
         'Label': row.Label,
         'Enzyme': row.Enzyme,
-        'PrecursorMassTolerance': row.PrecursorMassTolerance,
-        'PrecursorMassToleranceUnit': row.PrecursorMassToleranceUnit,
-        'FragmentMassTolerance': row.FragmentMassTolerance,
-        'FragmentMassToleranceUnit': row.FragmentMassToleranceUnit,
-        'FixedModifications': row.FixedModifications,
-        'VariableModifications': row.VariableModifications
+        'FixedModifications': row.FixedModifications
     ]
 
     def missingColumns = []
@@ -133,40 +128,66 @@ def create_meta_channel(LinkedHashMap row, enzymes, files, wrapper) {
         exit(1)
     }
 
-    // Validate tolerance values are valid numbers
-    try {
-        Double.parseDouble(row.PrecursorMassTolerance)
-    } catch (NumberFormatException e) {
-        log.error("ERROR: Invalid PrecursorMassTolerance value '${row.PrecursorMassTolerance}' for file '${filestr}'. Must be a valid number.")
-        exit(1)
-    }
-
-    try {
-        Double.parseDouble(row.FragmentMassTolerance)
-    } catch (NumberFormatException e) {
-        log.error("ERROR: Invalid FragmentMassTolerance value '${row.FragmentMassTolerance}' for file '${filestr}'. Must be a valid number.")
-        exit(1)
-    }
-
-    // Validate tolerance units
-    def validUnits = ['ppm', 'da', 'Da', 'PPM']
-    if (!validUnits.any { row.PrecursorMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
-        log.error("ERROR: Invalid PrecursorMassToleranceUnit '${row.PrecursorMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
-        exit(1)
-    }
-    if (!validUnits.any { row.FragmentMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
-        log.error("ERROR: Invalid FragmentMassToleranceUnit '${row.FragmentMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
-        exit(1)
-    }
-
+    // Set values from SDRF (required columns)
     meta.labelling_type = row.Label
     meta.fixedmodifications = row.FixedModifications
-    meta.variablemodifications = row.VariableModifications
-    meta.precursormasstolerance = Double.parseDouble(row.PrecursorMassTolerance)
-    meta.precursormasstoleranceunit = row.PrecursorMassToleranceUnit
-    meta.fragmentmasstolerance = Double.parseDouble(row.FragmentMassTolerance)
-    meta.fragmentmasstoleranceunit = row.FragmentMassToleranceUnit
     meta.enzyme = row.Enzyme
+
+    // Set tolerance values: use SDRF if available, otherwise fall back to params
+    def validUnits = ['ppm', 'da', 'Da', 'PPM']
+
+    // Precursor mass tolerance
+    if (row.PrecursorMassTolerance != null && !row.PrecursorMassTolerance.toString().trim().isEmpty()) {
+        try {
+            meta.precursormasstolerance = Double.parseDouble(row.PrecursorMassTolerance)
+        } catch (NumberFormatException e) {
+            log.error("ERROR: Invalid PrecursorMassTolerance value '${row.PrecursorMassTolerance}' for file '${filestr}'. Must be a valid number.")
+            exit(1)
+        }
+    } else {
+        meta.precursormasstolerance = params.precursor_mass_tolerance
+    }
+
+    // Precursor mass tolerance unit
+    if (row.PrecursorMassToleranceUnit != null && !row.PrecursorMassToleranceUnit.toString().trim().isEmpty()) {
+        if (!validUnits.any { row.PrecursorMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
+            log.error("ERROR: Invalid PrecursorMassToleranceUnit '${row.PrecursorMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
+            exit(1)
+        }
+        meta.precursormasstoleranceunit = row.PrecursorMassToleranceUnit
+    } else {
+        meta.precursormasstoleranceunit = params.precursor_mass_tolerance_unit
+    }
+
+    // Fragment mass tolerance
+    if (row.FragmentMassTolerance != null && !row.FragmentMassTolerance.toString().trim().isEmpty()) {
+        try {
+            meta.fragmentmasstolerance = Double.parseDouble(row.FragmentMassTolerance)
+        } catch (NumberFormatException e) {
+            log.error("ERROR: Invalid FragmentMassTolerance value '${row.FragmentMassTolerance}' for file '${filestr}'. Must be a valid number.")
+            exit(1)
+        }
+    } else {
+        meta.fragmentmasstolerance = params.fragment_mass_tolerance
+    }
+
+    // Fragment mass tolerance unit
+    if (row.FragmentMassToleranceUnit != null && !row.FragmentMassToleranceUnit.toString().trim().isEmpty()) {
+        if (!validUnits.any { row.FragmentMassToleranceUnit.toString().equalsIgnoreCase(it) }) {
+            log.error("ERROR: Invalid FragmentMassToleranceUnit '${row.FragmentMassToleranceUnit}' for file '${filestr}'. Must be 'ppm' or 'Da'.")
+            exit(1)
+        }
+        meta.fragmentmasstoleranceunit = row.FragmentMassToleranceUnit
+    } else {
+        meta.fragmentmasstoleranceunit = params.fragment_mass_tolerance_unit
+    }
+
+    // Variable modifications: use SDRF if available, otherwise fall back to params
+    if (row.VariableModifications != null && !row.VariableModifications.toString().trim().isEmpty()) {
+        meta.variablemodifications = row.VariableModifications
+    } else {
+        meta.variablemodifications = params.variable_mods
+    }
 
     enzymes += row.Enzyme
     if (enzymes.size() > 1) {


### PR DESCRIPTION
Remove 9 parameters that are now exclusively read from SDRF files:
- acquisition_method
- labelling_type
- enzyme
- precursor_mass_tolerance
- precursor_mass_tolerance_unit
- fragment_mass_tolerance
- fragment_mass_tolerance_unit
- fixed_mods
- variable_mods

These parameters were redundant as SDRF already contains all this metadata. The pipeline now requires proper SDRF annotation for these values, making the configuration simpler and reducing confusion.

Updated files:
- nextflow.config: Removed default parameter definitions
- nextflow_schema.json: Removed schema entries and updated help text
- conf/tests/test_lfq.config: Removed deprecated test params
- conf/tests/test_lfq_sage.config: Removed deprecated test params

Fixes #650

<!--
# bigbio/quantms pull request

Many thanks for contributing to bigbio/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantms/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
