### PR TITLE
fix: IsobaricWorkflow - auto-detect labelling type, pass isotope correction and extraction params

### DIFF
--- a/modules/local/openms/isobaric_workflow/main.nf
+++ b/modules/local/openms/isobaric_workflow/main.nf
@@ -8,6 +8,7 @@ process ISOBARIC_WORKFLOW {
         'ghcr.io/bigbio/openms-tools-thirdparty:2025.04.14' }"
 
     input:
+    val(labelling_type)
     path(mzmls)
     path(id_files)
     path(expdes)
@@ -38,19 +39,41 @@ process ISOBARIC_WORKFLOW {
         extractBaseName(a.name) <=> extractBaseName(b.name)
     }
 
+    // Build isotope correction matrix argument if enabled
+    def isotope_correction = ""
+    if (params.isotope_correction && params.plex_corr_matrix_file != null) {
+        def matrix_lines = new File(params.plex_corr_matrix_file).readLines()
+            .findAll { !it.startsWith('#') && it.trim() }
+            .drop(1)
+            .collect { line ->
+                def values = line.split('/')
+                if (labelling_type == 'tmt18plex' || labelling_type == 'tmt16plex') {
+                    return "\"${values[1]}/${values[2]}/${values[3]}/${values[4]}/${values[5]}/${values[6]}/${values[7]}/${values[8]}\""
+                } else {
+                    return "\"${values[1]}/${values[2]}/${values[3]}/${values[4]}\""
+                }
+            }
+        def correction_matrix = matrix_lines.join(" ")
+        isotope_correction = "-quantification:isotope_correction true -${labelling_type}:correction_matrix ${correction_matrix}"
+    }
+
     """
     IsobaricWorkflow \\
         -threads ${task.cpus} \\
         -in ${mzml_sorted.join(' ')} \\
         -in_id ${id_sorted.join(' ')} \\
         -exp_design ${expdes} \\
-        -type ${params.type} \\
+        -type ${labelling_type} \\
         -inference_method ${params.protein_inference_method} \\
         -protein_quantification ${params.protein_quant} \\
         -psmFDR ${params.psm_level_fdr_cutoff} \\
         -proteinFDR ${params.protein_level_fdr_cutoff} \\
         -picked_fdr ${params.picked_fdr} \\
         -picked_decoy_string ${params.decoy_string} \\
+        -extraction:min_precursor_purity ${params.min_precursor_purity} \\
+        -extraction:precursor_isotope_deviation ${params.precursor_isotope_deviation} \\
+        -extraction:min_reporter_intensity ${params.min_reporter_intensity} \\
+        ${isotope_correction} \\
         -out ${expdes.baseName}_openms.consensusXML \\
         -out_mzTab ${expdes.baseName}_openms.mzTab \\
         $args \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -178,9 +178,6 @@ params {
     add_triqler_output       = false
     quantify_decoys          = false
 
-    // IsobaricWorkflow flags
-    type                     = 'itraq4plex'
-
     // ProteomicsLFQ MBR parameters
     targeted_only            = true // If false MBR will be applied for quantification of all proteins
     feature_with_id_min_score = 0.10

--- a/workflows/tmt.nf
+++ b/workflows/tmt.nf
@@ -41,13 +41,16 @@ workflow TMT {
     //
     // SUBWORKFLOW: ISOBARIC_WORKFLOW
     //
+    // Extract labelling_type from meta (auto-detected from SDRF)
     ch_file_preparation_results.join(ID.out.id_results)
         .multiMap { it ->
-            mzmls: pmultiqc_mzmls: it[1]
+            labelling_type: it[0].labelling_type
+            mzmls: it[1]
             ids: it[2]
         }
         .set{ ch_iso_workflow }
-    ISOBARIC_WORKFLOW(ch_iso_workflow.mzmls.collect(),
+    ISOBARIC_WORKFLOW(ch_iso_workflow.labelling_type.first(),
+                ch_iso_workflow.mzmls.collect(),
                 ch_iso_workflow.ids.collect(),
                 ch_expdesign
             )


### PR DESCRIPTION
## Summary

Fixes several issues in the IsobaricWorkflow integration (PR #604) to make it ready for merge:

- **Auto-detect labelling type from SDRF** instead of hardcoded `params.type='itraq4plex'`. The `labelling_type` is extracted from the meta channel (already parsed from SDRF), matching how `IsobaricAnalyzer` works.
- **Pass isotope correction matrix** when `params.isotope_correction` is enabled, using the same correction matrix parsing logic as `IsobaricAnalyzer`
- **Pass extraction parameters** (`min_precursor_purity`, `precursor_isotope_deviation`, `min_reporter_intensity`) that were missing from the IsobaricWorkflow invocation
- **Remove unused `type` parameter** from `nextflow.config` (no longer needed since type is auto-detected)

## Changes

| File | Change |
|------|--------|
| `modules/local/openms/isobaric_workflow/main.nf` | Add `labelling_type` input, isotope correction matrix handling, extraction params |
| `workflows/tmt.nf` | Extract `labelling_type` from meta channel and pass to IsobaricWorkflow |
| `nextflow.config` | Remove hardcoded `type = 'itraq4plex'` |

## Test plan

- [ ] Run with TMT16plex dataset — verify labelling_type is correctly auto-detected
- [ ] Run with isotope_correction enabled — verify correction matrix is passed
- [ ] Run with iTRAQ4plex dataset — verify 4-plex correction matrix format works

🤖 Generated with [Claude Code](https://claude.com/claude-code)