### PR TITLE
feat: expose Biosaur2 as alternative feature seeding algorithm for LFQ

### DIFF
--- a/modules/local/openms/proteomicslfq/main.nf
+++ b/modules/local/openms/proteomicslfq/main.nf
@@ -48,6 +48,7 @@ process PROTEOMICSLFQ {
         ${feature_with_id_min_score} \\
         ${feature_without_id_min_score} \\
         -mass_recalibration ${params.mass_recalibration} \\
+        -Seeding:algorithm ${params.lfq_seeding_algorithm} \\
         -Seeding:intThreshold ${params.lfq_intensity_threshold} \\
         -protein_quantification ${params.protein_quant} \\
         -alignment_order ${params.alignment_order} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -185,6 +185,7 @@ params {
     protein_inference_method = 'aggregation'
     protein_quant            = 'unique_peptides'
     quantification_method    = 'feature_intensity'
+    lfq_seeding_algorithm    = 'multiplex'  // Feature seeding: 'multiplex' (default) or 'biosaur2'
     mass_recalibration       = false
     alignment_order          = 'star'
     quantify_decoys          = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1064,6 +1064,13 @@
                     "enum": ["feature_intensity", "spectral_counting"],
                     "fa_icon": "fas fa-list-ol"
                 },
+                "lfq_seeding_algorithm": {
+                    "type": "string",
+                    "description": "Feature detection seeding algorithm for ProteomicsLFQ. 'multiplex' uses FeatureFinderMultiplex (default), 'biosaur2' uses the Biosaur2 algorithm.",
+                    "default": "multiplex",
+                    "enum": ["multiplex", "biosaur2"],
+                    "fa_icon": "fas fa-seedling"
+                },
                 "mass_recalibration": {
                     "type": "boolean",
                     "description": "Recalibrates masses based on precursor mass deviations to correct for instrument biases. (default: 'false')",


### PR DESCRIPTION
## Summary

Add `lfq_seeding_algorithm` parameter to select the feature detection seeding algorithm in ProteomicsLFQ:

- `multiplex` (default) — FeatureFinderMultiplex, current behavior
- `biosaur2` — Biosaur2 algorithm, recently added to OpenMS ([#8385](https://github.com/OpenMS/OpenMS/pull/8385))

## What is Biosaur2?

A C++ reimplementation of the [Biosaur2](https://github.com/markmipt/biosaur2) feature detection algorithm (Abdrakhimov et al., RCMS 2022). It detects peptide features by building RT traces ("hills"), splitting at valleys, and assembling isotopic patterns with cosine scoring.

ProteomicsLFQ already tunes the Biosaur2 defaults internally (`mini=500`, `minlh=3`), so no additional parameters need to be exposed.

## Changes

| File | Change |
|------|--------|
| `modules/local/openms/proteomicslfq/main.nf` | Pass `-Seeding:algorithm ${params.lfq_seeding_algorithm}` |
| `nextflow.config` | Add `lfq_seeding_algorithm = 'multiplex'` |
| `nextflow_schema.json` | Document the parameter |

## Test plan

- [ ] Default (`multiplex`) produces identical results to current version
- [ ] `lfq_seeding_algorithm = 'biosaur2'` runs successfully on a standard LFQ dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)