### PR TITLE
fix(pride config): scale ISOBARIC_WORKFLOW and MSSTATS_CONVERTER with experiment size

### DIFF
--- a/conf/pride_codon_slurm.config
+++ b/conf/pride_codon_slurm.config
@@ -42,6 +42,34 @@ process {
         cpus   = {(mzmls as List).size() < 200 ? 12 * task.attempt : 24 * task.attempt }
     }
 
+    // The isobaric (TMT/iTRAQ) counterpart of PROTEOMICSLFQ: a SINGLE process that
+    // loads every run's IDs + features and runs protein inference (EPIFANY) over the
+    // whole experiment, so it scales with the experiment, not with one file. Measured
+    // on MSV000085836 (552 fractions): the label default of 72 GB was OOM-killed
+    // (exit 137) after 2h36m and only succeeded on the retry escalation, with a peak
+    // RSS of 118.7 GB. Start large for big experiments instead of burning hours on a
+    // first attempt that cannot fit.
+    withName:ISOBARIC_WORKFLOW{
+        memory = {(mzmls as List).size() < 200 ? 72.GB * task.attempt : 250.GB * task.attempt }
+        cpus   = {(mzmls as List).size() < 200 ? 12 * task.attempt : 24 * task.attempt }
+    }
+
+    // MSSTATS_CONVERTER also aggregates the whole experiment, but its input is the one
+    // merged consensusXML rather than a file list, so scale on that file's size. On the
+    // same 552-fraction run the 12 GB default was OOM-killed 9 times in a row: the
+    // retry ladder never reaches a workable size, so the run dies after every attempt.
+    // NOTE on .size(): for a single Path it is the file's BYTES, but for a List it is
+    // the element COUNT. consensusXML is currently one file (tmt.nf passes
+    // ISOBARIC_WORKFLOW.out.out_consensusXML), so guard the List case explicitly -
+    // otherwise a future change to a collected channel would silently always take the
+    // small branch and reintroduce the OOM.
+    withName:MSSTATS_CONVERTER{
+        memory = {
+            def bytes = (consensusXML instanceof List) ? consensusXML.sum { it.size() } : consensusXML.size()
+            bytes < 2_000_000_000 ? 24.GB * task.attempt : 200.GB * task.attempt
+        }
+    }
+
     withName:ASSEMBLE_EMPIRICAL_LIBRARY{
         memory = {(ms_files as List).size() < 200 ? 72.GB * task.attempt : 250.GB * task.attempt}
         cpus   = {(ms_files as List).size() < 200 ? 12 * task.attempt : 24 * task.attempt }


### PR DESCRIPTION
## Problem

`ISOBARIC_WORKFLOW` and `MSSTATS_CONVERTER` are **single processes that aggregate the whole experiment** — like `PROTEOMICSLFQ`, which this config already scales. Their per-file defaults do not fit large runs, and both failed on a real 552-fraction TMT dataset (MSV000085836) under `pride_codon_slurm`:

| process | default | outcome |
|---|---|---|
| `ISOBARIC_WORKFLOW` | 72 GB | OOM (exit 137) after **2h36m**; succeeded only via retry escalation, **peak RSS 118.7 GB** |
| `MSSTATS_CONVERTER` | 12 GB | **OOM-killed 9 times in a row** — the run died after exhausting attempts |

`MSSTATS_CONVERTER` is the worse of the two: starting at 12 GB, the `* task.attempt` ladder never reaches a workable size for an experiment this big, so *every* attempt dies and the pipeline fails after ~17 hours of otherwise-successful work (conversion, both search engines, ms2features, Percolator and protein inference had all completed).

## Fix

Scale both with the experiment, reusing the pattern already established here for `PROTEOMICSLFQ` / `ASSEMBLE_EMPIRICAL_LIBRARY`:

- **`ISOBARIC_WORKFLOW`** takes the same `path(mzmls)` input as `PROTEOMICSLFQ`, so it reuses the identical file-count rule (`< 200 files ? 72 GB : 250 GB`, × `task.attempt`).
- **`MSSTATS_CONVERTER`** receives the single merged `consensusXML` rather than a file list, so it scales on **that file's size** instead (`< 2 GB ? 24 GB : 200 GB`, × `task.attempt`).

## One subtlety worth reviewing

`.size()` means **bytes** for a single `Path` but **element count** for a `List`. `consensusXML` is currently a single file (`tmt.nf:61` passes `ISOBARIC_WORKFLOW.out.out_consensusXML`), so the byte reading is correct today — but the closure guards the `List` case explicitly, because a future change to a collected channel would otherwise silently take the small branch and quietly reintroduce exactly this OOM.

## Notes

- Both ceilings sit well under the profile's `resourceLimits` (1900 GB) and fit standard ~480 GB nodes, so no `bigmem` routing is needed.
- Thresholds are deliberately the same shape as the existing entries rather than a new mechanism; the intent is that big experiments *start* at a workable size instead of discovering it through the retry ladder.
