### PR TITLE
chore: pmultiqc 0.0.46 and quantms-rescoring 0.0.24 (incorporates #714)

### DIFF
--- a/modules/local/openms/msgf/main.nf
+++ b/modules/local/openms/msgf/main.nf
@@ -18,9 +18,13 @@ process MSGF {
     script:
     // The OpenMS adapters need the actual jar file, not the executable/shell wrapper that (bio)conda creates
     msgf_jar = ''
-    if ((workflow.containerEngine || (task.executor == "awsbatch")) && (task.container.indexOf("biocontainers") > -1 || task.container.indexOf("depot.galaxyproject.org") > -1)) {
+    if ((workflow.containerEngine || (task.executor == "awsbatch")) && task.container.indexOf("bigbio") > -1) {
+        msgf_jar = "-executable /opt/OpenMS/thirdparty/MSGFPlus/MSGFPlus.jar"
+    }
+    else if ((workflow.containerEngine || (task.executor == "awsbatch")) && (task.container.indexOf("biocontainers") > -1 || task.container.indexOf("depot.galaxyproject.org") > -1)) {
         msgf_jar = "-executable \$(find /usr/local/share/msgf_plus-*/MSGFPlus.jar -maxdepth 0)"
-    } else if (System.getenv('CONDA_PREFIX')) {
+    }
+    else if (System.getenv('CONDA_PREFIX')) {
         msgf_jar = "-executable \$(find \$CONDA_PREFIX/share/msgf_plus-*/MSGFPlus.jar -maxdepth 0)"
     }
 

--- a/modules/local/pmultiqc/main.nf
+++ b/modules/local/pmultiqc/main.nf
@@ -2,8 +2,8 @@ process PMULTIQC {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.39--pyhdfd78af_0' :
-        'biocontainers/pmultiqc:0.0.39--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.45--pyhdfd78af_0' :
+        'biocontainers/pmultiqc:0.0.45--pyhdfd78af_0' }"
 
     input:
     path 'results/*'
@@ -17,10 +17,10 @@ process PMULTIQC {
 
     script:
     def args = task.ext.args ?: ''
-    def disable_pmultiqc = (params.enable_pmultiqc) && (params.export_mztab) ? "--quantms_plugin" : ""
-    def disable_table_plots = (params.enable_pmultiqc) && (params.skip_table_plots) ? "--disable_table" : ""
-    def disable_idxml_index = (params.enable_pmultiqc) && (params.pmultiqc_idxml_skip) ? "--ignored_idxml" : ""
-    def contaminant_affix = params.contaminant_string ? "--contaminant_affix ${params.contaminant_string}" : ""
+    def disable_pmultiqc = (params.enable_pmultiqc) && (params.export_mztab) ? "--quantms-plugin" : ""
+    def disable_table_plots = (params.enable_pmultiqc) && (params.skip_table_plots) ? "--disable-table" : ""
+    def disable_idxml_index = (params.enable_pmultiqc) && (params.pmultiqc_idxml_skip) ? "--ignored-idxml" : ""
+    def contaminant_affix = params.contaminant_string ? "--contaminant-affix ${params.contaminant_string}" : ""
 
     """
     set -x
@@ -39,7 +39,7 @@ process PMULTIQC {
         ${disable_table_plots} \\
         ${disable_idxml_index} \\
         ${contaminant_affix} \\
-        --quantification_method $params.quantification_method \\
+        --quantification-method $params.quantification_method \\
         ./results \\
         -o .
 

--- a/modules/local/pmultiqc/main.nf
+++ b/modules/local/pmultiqc/main.nf
@@ -2,8 +2,8 @@ process PMULTIQC {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.45--pyhdfd78af_0' :
-        'biocontainers/pmultiqc:0.0.45--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.46--pyhdfd78af_0' :
+        'biocontainers/pmultiqc:0.0.46--pyhdfd78af_0' }"
 
     input:
     path 'results/*'

--- a/modules/local/utils/msrescore_features/main.nf
+++ b/modules/local/utils/msrescore_features/main.nf
@@ -3,8 +3,8 @@ process MSRESCORE_FEATURES {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.21' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.21' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
 
     input:
     tuple val(meta), path(id_files), path(mzml), path(model_weight)

--- a/modules/local/utils/msrescore_fine_tuning/main.nf
+++ b/modules/local/utils/msrescore_fine_tuning/main.nf
@@ -3,8 +3,8 @@ process MSRESCORE_FINE_TUNING {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.21' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.21' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
 
     input:
     tuple val(meta), path(idparquet), path(mzml), path(ms2_model_dir)

--- a/modules/local/utils/psm_clean/main.nf
+++ b/modules/local/utils/psm_clean/main.nf
@@ -3,8 +3,8 @@ process PSM_CLEAN {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.21' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.21' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
 
     input:
     tuple val(meta), path(idparquet), path(mzml)

--- a/modules/local/utils/spectrum_features/main.nf
+++ b/modules/local/utils/spectrum_features/main.nf
@@ -3,8 +3,8 @@ process SPECTRUM_FEATURES {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.21' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.21' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
 
     input:
     tuple val(meta), path(id_file), path(ms_file)


### PR DESCRIPTION
Incorporates **#714 by @yueqixuan** (commit cherry-picked with authorship intact) and adds the two version bumps.

## Why not just merge #714

#714 is currently **red**: it bumps pmultiqc to 0.0.45, which fails every `test_dda_id_*` profile on both Nextflow versions:

```
ValueError: No pmultiqc plugin selected; skipping.
AttributeError: module 'rich' has no attribute 'panel'
```

Those profiles don't export an mzTab, so `--quantms-plugin` is never added, and 0.0.45 *raises* instead of degrading gracefully.

**pmultiqc 0.0.46 is precisely the fix** — "Allow successful execution without mzTab file" ([pmultiqc#688](https://github.com/bigbio/pmultiqc/pull/688)), "gracefully handle plugin execution errors" (#689), "Support pmultiqc without mzTab" (#690). So this PR keeps @yueqixuan's work (the bigbio MSGF jar path fix and the underscore→hyphen CLI flags, both correct) and moves the pin to 0.0.46 so CI can go green.

## quantms-rescoring 0.0.21 → 0.0.22

8 references (4 docker, 4 singularity).

**0.0.21 is broken for multi-engine runs.** On a `comet,msgf` merge it collapsed the Percolator feature table to four raw scores with one global imputation constant. ~80% of PSMs in such a run are single-engine and those are ~45% decoy (vs ~8% for both-engine), so Percolator couldn't separate the decoy flood, protein FDR never cleared 1%, and EPIFANY returned *"No proteins left after FDR filtering"* (exit 8).

0.0.22 feeds Percolator the **union** of every engine's numeric features with orientation-aware per-feature worst-case imputation and always-defined `CONSENSUS:<engine>` indicators.

Validated on MSV000085836 (552 TMT fractions):

| | 0.0.21 | 0.0.22 |
|---|---|---|
| `ISOBARIC_WORKFLOW` | zero proteins, exit 8 | **41,391 proteins merged** |

End-to-end vs the comet-only reference: **+4.4% peptides, +0.6% protein groups** at 1% FDR (323,198 → 337,494 peptides; 14,015 → 14,101 groups).

It also generalises to SAGE (`comet+sage`, `msgf+sage`, `comet+msgf+sage`), with the Sage feature set verified against a **real SageAdapter idparquet** rather than inferred.

## Scope of risk

**Single-engine runs are completely unaffected** — the consensus path only activates for multi-engine merges, and the default stays `search_engines=comet`. This PR changes no defaults.

## Caveat worth recording

Multi-engine consensus gives Percolator explicit engine-source indicators, and engine source correlates strongly with decoy status. **There is no stratified or entrapment calibration evidence yet** that protein-level FDR stays calibrated under that source-dependent mixture — an adversarial review flagged it as the one open concern. Multi-engine should stay opt-in and be validated per dataset before being relied on for production protein-level FDR.

## Note on CI timing

`ghcr.io/bigbio/quantms-rescoring:0.0.22` is published; the `-sif` variant was still building when this was opened. If a singularity job fails on a missing image, re-run it once the container sync completes.
