### PR TITLE
chore: pin quantms-rescoring 0.0.23 (0.0.22 was broken for multi-engine)

### DIFF
--- a/modules/local/utils/msrescore_features/main.nf
+++ b/modules/local/utils/msrescore_features/main.nf
@@ -3,8 +3,8 @@ process MSRESCORE_FEATURES {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.23' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.23' }"
 
     input:
     tuple val(meta), path(id_files), path(mzml), path(model_weight)

--- a/modules/local/utils/msrescore_fine_tuning/main.nf
+++ b/modules/local/utils/msrescore_fine_tuning/main.nf
@@ -3,8 +3,8 @@ process MSRESCORE_FINE_TUNING {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.23' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.23' }"
 
     input:
     tuple val(meta), path(idparquet), path(mzml), path(ms2_model_dir)

--- a/modules/local/utils/psm_clean/main.nf
+++ b/modules/local/utils/psm_clean/main.nf
@@ -3,8 +3,8 @@ process PSM_CLEAN {
     label 'process_high'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.23' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.23' }"
 
     input:
     tuple val(meta), path(idparquet), path(mzml)

--- a/modules/local/utils/spectrum_features/main.nf
+++ b/modules/local/utils/spectrum_features/main.nf
@@ -3,8 +3,8 @@ process SPECTRUM_FEATURES {
     label 'process_low'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.22' :
-        'ghcr.io/bigbio/quantms-rescoring:0.0.22' }"
+        'oras://ghcr.io/bigbio/quantms-rescoring-sif:0.0.23' :
+        'ghcr.io/bigbio/quantms-rescoring:0.0.23' }"
 
     input:
     tuple val(meta), path(id_file), path(ms_file)


### PR DESCRIPTION
0.0.22 raised ValueError on every comet,msgf / *+sage merge (numpy-array truth-test on sp_metavalues). 0.0.23 fixes it; the multi-engine test (test_psm_clean_multi_engine) is green in the 0.0.23 release CI.

<!--
# bigbio/quantms pull request

Many thanks for contributing to bigbio/quantms!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/bigbio/quantms/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/bigbio/quantms/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the bigbio/quantms _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
