### PR TITLE
chore(modules): re-vendor pmultiqc 0.0.48 and qpx 1.1.3 from nf-modules

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -12,7 +12,7 @@
                     },
                     "qpx/openmsconsensus": {
                         "branch": "main",
-                        "git_sha": "0e150a75761e379ab1e95c9fb8f0e42164bb5485",
+                        "git_sha": "7cd54b39383fed0257b916e1060608b7ef322023",
                         "installed_by": ["modules"]
                     },
                     "thermorawfileparser": {
@@ -23,7 +23,7 @@
                     },
                     "pmultiqc": {
                         "branch": "main",
-                        "git_sha": "0e150a75761e379ab1e95c9fb8f0e42164bb5485",
+                        "git_sha": "7cd54b39383fed0257b916e1060608b7ef322023",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules.json
+++ b/modules.json
@@ -12,7 +12,7 @@
                     },
                     "qpx/openmsconsensus": {
                         "branch": "main",
-                        "git_sha": "21b7fa083b9400c6a276629fbf3ae8500493d518",
+                        "git_sha": "0e150a75761e379ab1e95c9fb8f0e42164bb5485",
                         "installed_by": ["modules"]
                     },
                     "thermorawfileparser": {
@@ -23,7 +23,7 @@
                     },
                     "pmultiqc": {
                         "branch": "main",
-                        "git_sha": "108392261b83e7e45681c3462a92549ffa1f5db3",
+                        "git_sha": "0e150a75761e379ab1e95c9fb8f0e42164bb5485",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/bigbio/pmultiqc/environment.yml
+++ b/modules/bigbio/pmultiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::pmultiqc=0.0.47
+  - bioconda::pmultiqc=0.0.48

--- a/modules/bigbio/pmultiqc/main.nf
+++ b/modules/bigbio/pmultiqc/main.nf
@@ -5,8 +5,8 @@ process PMULTIQC {
     // pmultiqc is published to bioconda/biocontainers on release; a single image
     // serves Docker (native) and Singularity (via the galaxy depot mirror).
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.47--pyhdfd78af_0' :
-        'biocontainers/pmultiqc:0.0.47--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pmultiqc:0.0.48--pyhdfd78af_0' :
+        'biocontainers/pmultiqc:0.0.48--pyhdfd78af_0' }"
 
     input:
     // Everything the report needs, staged flat under `results/`. Consumers collect
@@ -45,7 +45,7 @@ process PMULTIQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        pmultiqc: \$(multiqc --pmultiqc_version | sed -e "s/pmultiqc, version //g" 2>/dev/null || echo "0.0.47")
+        pmultiqc: \$(multiqc --pmultiqc_version | sed -e "s/pmultiqc, version //g" 2>/dev/null || echo "0.0.48")
     END_VERSIONS
     """
 }

--- a/modules/bigbio/qpx/openmsconsensus/environment.yml
+++ b/modules/bigbio/qpx/openmsconsensus/environment.yml
@@ -2,9 +2,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  # qpx 1.1.1 is on PyPI now; bioconda lags a release, so pin the PyPI release to
-  # match the GHCR container version. Switch to `bioconda::qpx=1.1.1` once bioconda
+  # qpx is on PyPI; bioconda lags a release, so pin the PyPI release to match the
+  # GHCR container version. Switch to `bioconda::qpx=<version>` once bioconda
   # publishes it.
   - pip
   - pip:
-      - qpx==1.1.2
+      - qpx==1.1.3

--- a/modules/bigbio/qpx/openmsconsensus/main.nf
+++ b/modules/bigbio/qpx/openmsconsensus/main.nf
@@ -8,7 +8,7 @@ process QPX_OPENMSCONSENSUS {
     // a single image serves Docker (native) and Singularity (via docker://).
     // BioContainers/Galaxy-depot lag the release, so GHCR is used for containers;
     // -profile conda still resolves the bioconda package in environment.yml.
-    container "ghcr.io/bigbio/qpx:1.1.2"
+    container "ghcr.io/bigbio/qpx:1.1.3"
 
     input:
     path(consensusxml)

--- a/modules/bigbio/qpx/openmsconsensus/tests/main.nf.test
+++ b/modules/bigbio/qpx/openmsconsensus/tests/main.nf.test
@@ -1,0 +1,43 @@
+nextflow_process {
+
+    name "Test Process QPX_OPENMSCONSENSUS"
+    script "../main.nf"
+    process "QPX_OPENMSCONSENSUS"
+    tag "modules"
+    tag "modules_bigbio"
+    tag "modules_qpx"
+    tag "qpx"
+
+    config "./nextflow.config"
+
+    // TODO real-data test: mirror the diann subtool's test once a small OpenMS
+    // consensusXML + SDRF fixture (`<ACC>.zip` with `openms.consensusXML` +
+    // `sample.sdrf.tsv`) is hosted under the PRIDE pmultiqc example-projects, then
+    // add a test that downloads it and asserts qpx_dataset/mudata/versions. The
+    // openms-consensus conversion + MuData build have been validated out-of-band
+    // against the qpx 1.1.1 container on a real 2-replicate consensusXML.
+    test("Should run stub mode") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = file("stub.consensusXML", checkIfExists: false)
+                input[1] = file("stub_sample.sdrf.tsv", checkIfExists: false)
+                input[2] = "PXD026600"
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert process.out.qpx_dataset.size() == 1
+            assert process.out.mudata.size() == 1
+            assert snapshot(
+                process.out.mudata,
+                process.out.versions
+            ).match("stub")
+        }
+    }
+}

--- a/modules/bigbio/qpx/openmsconsensus/tests/main.nf.test.snap
+++ b/modules/bigbio/qpx/openmsconsensus/tests/main.nf.test.snap
@@ -1,0 +1,17 @@
+{
+    "stub": {
+        "content": [
+            [
+                "PXD026600.h5mu:md5,d41d8cd98f00b204e9800998ecf8427e"
+            ],
+            [
+                "versions.yml:md5,cd256c9ccc3b75e0eb989b5b73eb52f2"
+            ]
+        ],
+        "timestamp": "2026-08-06T11:07:53.196146",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/bigbio/qpx/openmsconsensus/tests/nextflow.config
+++ b/modules/bigbio/qpx/openmsconsensus/tests/nextflow.config
@@ -1,0 +1,9 @@
+process {
+    withName: 'QPX_OPENMSCONSENSUS' {
+        ext.args = ''
+    }
+}
+
+params {
+    qpx_version = 'dev'
+}


### PR DESCRIPTION
Re-vendors `modules/bigbio/pmultiqc` and `modules/bigbio/qpx/openmsconsensus` from bigbio/nf-modules main (`0e150a7`, after bigbio/nf-modules#50), and bumps both `git_sha` entries in `modules.json` to match.

| module | from | to |
|---|---|---|
| pmultiqc | 0.0.47 | 0.0.48 |
| qpx/openmsconsensus | 1.1.2 | 1.1.3 |

**pmultiqc 0.0.48** is the big-DIA memory release. The summary step for PXD030304 previously OOM'd at 234 GB; it now completes at a **68.0 GiB peak in 15 min**, with the module present and all sections rendered.

### Verified before pinning

Every artifact was confirmed to resolve rather than assumed: galaxy-depot singularity `pmultiqc:0.0.48--pyhdfd78af_0`, quay biocontainers 0.0.48, `bioconda::pmultiqc=0.0.48`, and `ghcr.io/bigbio/qpx:1.1.3`.

### One disclosed divergence

`qpx/openmsconsensus/environment.yml` here carries the **version-agnostic** bioconda comment from bigbio/nf-modules#51, which is not yet merged. On nf-modules main today that comment still reads `bioconda::qpx=1.1.2` directly above a `qpx==1.1.3` pin — i.e. it contradicts the line under it. I kept the corrected wording rather than vendor a self-contradicting comment. Once #51 merges the two match exactly; until then this one comment differs from the recorded `git_sha`. Nothing functional depends on it.

### Also included

`modules/bigbio/qpx/openmsconsensus/tests/` — upstream has these and this checkout did not, so the vendored copy was incomplete.